### PR TITLE
Add React slider page and Swing client

### DIFF
--- a/src/main/java/cst8218/jeffin/slider/client/SliderSwingClient.java
+++ b/src/main/java/cst8218/jeffin/slider/client/SliderSwingClient.java
@@ -1,0 +1,56 @@
+package cst8218.jeffin.slider.client;
+
+import java.awt.FlowLayout;
+import java.awt.event.ActionEvent;
+import java.net.URI;
+import javax.swing.*;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+/**
+ * Simple Swing client that allows updating a slider's size via the REST API.
+ */
+public class SliderSwingClient {
+    private static final String API_BASE = "http://localhost:8080/Web-Assignment2/resources/slider";
+
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(SliderSwingClient::createAndShow);
+    }
+
+    private static void createAndShow() {
+        JFrame frame = new JFrame("Slider Client");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setLayout(new FlowLayout());
+
+        JTextField idField = new JTextField(5);
+        JTextField sizeField = new JTextField(5);
+        JButton update = new JButton("Update Size");
+
+        update.addActionListener((ActionEvent e) -> {
+            try {
+                long id = Long.parseLong(idField.getText());
+                int size = Integer.parseInt(sizeField.getText());
+                String json = String.format("{\"id\":%d,\"size\":%d}", id, size);
+                HttpRequest request = HttpRequest.newBuilder()
+                        .uri(URI.create(API_BASE + "/" + id))
+                        .header("Content-Type", "application/json")
+                        .PUT(HttpRequest.BodyPublishers.ofString(json))
+                        .build();
+                HttpClient.newHttpClient()
+                        .sendAsync(request, HttpResponse.BodyHandlers.ofString())
+                        .thenAccept(resp -> System.out.println("Response: " + resp.body()));
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            }
+        });
+
+        frame.add(new JLabel("ID:"));
+        frame.add(idField);
+        frame.add(new JLabel("Size:"));
+        frame.add(sizeField);
+        frame.add(update);
+        frame.pack();
+        frame.setVisible(true);
+    }
+}

--- a/src/main/webapp/index.xhtml
+++ b/src/main/webapp/index.xhtml
@@ -10,6 +10,8 @@
         Hello from Facelets
         <br />
         <h:link outcome="/slider/List" value="Show All Slider Items"/>
+        <br />
+        <a href="react-sliders.html">React Sliders Page</a>
     </h:body>
 
 </html>

--- a/src/main/webapp/react-sliders.html
+++ b/src/main/webapp/react-sliders.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Sliders React Page</title>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+    <style>
+      canvas { border:1px solid #000; }
+      ul { list-style: none; padding: 0; }
+      li { margin-bottom: 4px; }
+      input { width:60px; margin-left:4px; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel">
+      const apiBase = 'resources/slider';
+
+      function SliderApp() {
+        const [sliders, setSliders] = React.useState([]);
+        const canvasRef = React.useRef(null);
+
+        React.useEffect(() => {
+          fetch(apiBase)
+            .then(res => res.json())
+            .then(setSliders);
+        }, []);
+
+        React.useEffect(() => {
+          let animationFrame;
+          const move = () => {
+            setSliders(prev => prev.map(s => {
+              const dir = s.mvtDirection || 1;
+              const travel = (s.currentTravel || 0) + Math.abs(dir);
+              let newDir = dir;
+              if (s.maxTravel && travel >= s.maxTravel) {
+                newDir = -dir;
+              }
+              return {
+                ...s,
+                x: (s.x || 0) + newDir,
+                currentTravel: travel % (s.maxTravel || 100),
+                mvtDirection: newDir
+              };
+            }));
+            animationFrame = requestAnimationFrame(move);
+          };
+          animationFrame = requestAnimationFrame(move);
+          return () => cancelAnimationFrame(animationFrame);
+        }, []);
+
+        React.useEffect(() => {
+          const canvas = canvasRef.current;
+          if (!canvas) return;
+          const ctx = canvas.getContext('2d');
+          ctx.clearRect(0, 0, canvas.width, canvas.height);
+          sliders.forEach(s => {
+            ctx.fillRect(s.x || 0, s.y || 0, s.size || 10, s.size || 10);
+          });
+        }, [sliders]);
+
+        function updateSlider(id, field, value) {
+          const slider = sliders.find(s => s.id === id);
+          if (!slider) return;
+          const body = { ...slider, [field]: parseInt(value, 10) };
+          fetch(`${apiBase}/${id}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body)
+          })
+            .then(res => res.json())
+            .then(updated => {
+              setSliders(sliders.map(s => (s.id === id ? updated : s)));
+            });
+        }
+
+        return (
+          <div>
+            <canvas ref={canvasRef} width="500" height="300"></canvas>
+            <ul>
+              {sliders.map(s => (
+                <li key={s.id}>
+                  ID:{s.id}
+                  X:<input type="number" value={s.x || 0} onChange={e => updateSlider(s.id, 'x', e.target.value)} />
+                  Y:<input type="number" value={s.y || 0} onChange={e => updateSlider(s.id, 'y', e.target.value)} />
+                  Size:<input type="number" value={s.size || 0} onChange={e => updateSlider(s.id, 'size', e.target.value)} />
+                </li>
+              ))}
+            </ul>
+          </div>
+        );
+      }
+
+      ReactDOM.createRoot(document.getElementById('root')).render(<SliderApp />);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add React-based page to list and animate sliders with canvas and inline editing.
- Link new React page from existing JSF index.
- Provide Swing client to update slider size via REST API.

## Testing
- `mvn -q test` *(fails: Network is unreachable while resolving maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_688e721a6370832d8cf74b55d881dbf7